### PR TITLE
Do not pad SHA fingerprints for comparison with ssh-agent identities

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -260,7 +260,7 @@ fn sha256_fingerprint(bytes: &[u8]) -> String {
 
     let sum = hasher.result();
 
-    format!("SHA256:{}", base64::encode(&sum))
+    format!("SHA256:{}", base64::encode_config(&sum, base64::STANDARD_NO_PAD))
 }
 
 fn md5_fingerprint(bytes: &[u8]) -> String {


### PR DESCRIPTION
I was just taking a peek at the code and hit this when I tried to run it:

```
09:45:38:rust-manta(kelly-master) $ cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.03s
     Running `target/debug/rust-manta`
"/kelly.mclaughlin/stor"
ssh_auth_sock = /tmp/ssh-apYwGnC2qBHZ/agent.669
manta_key_id = SHA256:*****************************************
found 4 ssh identities
thread 'main' panicked at 'Failed to find key in ssh-agent', libcore/option.rs:914:5
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```

Works fine without the padding on the fingerprint:

```
09:47:21:rust-manta(kelly-master *) $ cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/rust-manta`
"/kelly.mclaughlin/stor"
ssh_auth_sock = /tmp/ssh-apYwGnC2qBHZ/agent.669
manta_key_id = SHA256:**************************************************
found 4 ssh identities
SshIdentity: ssh-rsa SHA256:******************************************

curl -sS --header 'date: Tue, 14 Aug 2018 15:47:24 GMT' --header 'authorization: Signature keyId="/kelly.mclaughlin/keys/***************************************",algorithm="rsa-sha1",headers="date",signature="..."' 'https://us-east.manta.joyent.com/kelly.mclaughlin/stor';echo

.joyent/
README.md
abc
tmp
```